### PR TITLE
feat: Add support of kafka 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All versions that listed on https://kafka.apache.org/downloads
 
 `docker pull ghcr.io/obalunenko/docker-kafka-zookeeper:latest`
 
-KAFKA_VERSION 3.5.1
+KAFKA_VERSION 3.6.1
 
 ZOOKEEPER_VERSION 3.4.13
 
@@ -38,17 +38,27 @@ SCALA_VERSION 2.13
 
 `docker pull ghcr.io/obalunenko/docker-kafka-zookeeper:stable`
 
-KAFKA_VERSION 3.5.1
+KAFKA_VERSION 3.6.1
 
 ZOOKEEPER_VERSION 3.4.13
 
 SCALA_VERSION 2.13
 
-### v3.5.1
+### v3.6.1
 
-`docker pull ghcr.io/obalunenko/docker-kafka-zookeeper:v3.5.1`
+`docker pull ghcr.io/obalunenko/docker-kafka-zookeeper:v3.6.1`
 
-KAFKA_VERSION 3.5.1
+KAFKA_VERSION 3.6.1
+
+ZOOKEEPER_VERSION 3.4.13
+
+SCALA_VERSION 2.13
+
+### v3.5.2
+
+`docker pull ghcr.io/obalunenko/docker-kafka-zookeeper:v3.5.2`
+
+KAFKA_VERSION 3.5.2
 
 ZOOKEEPER_VERSION 3.4.13
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -309,7 +309,7 @@ target "kafka-3_4" {
 target "kafka-3_5" {
   inherits = ["kafka_base"]
   args     = {
-    KAFKA_VERSION = "3.5.1",
+    KAFKA_VERSION = "3.5.2",
     SCALA_VERSION = "2.13"
   }
   tags = [
@@ -318,9 +318,21 @@ target "kafka-3_5" {
   ]
 }
 
+target "kafka-3_6" {
+  inherits = ["kafka_base"]
+  args     = {
+    KAFKA_VERSION = "3.6.1",
+    SCALA_VERSION = "2.13"
+  }
+  tags = [
+    "${IMAGE_WITH_REGISTRY}:3.6.1",
+    "${IMAGE_WITH_REGISTRY}:v3.6.1",
+  ]
+}
+
 
 target "kafka-stable" {
-  inherits = ["kafka-3_5"]
+  inherits = ["kafka-3_6"]
   tags     = [
     "${IMAGE_WITH_REGISTRY}:stable",
   ]
@@ -329,12 +341,12 @@ target "kafka-stable" {
 target "kafka-latest" {
   inherits = ["kafka_base"]
   args     = {
-    KAFKA_VERSION = "3.5.1",
+    KAFKA_VERSION = "3.6.1",
     SCALA_VERSION = "2.13"
   }
   tags = [
     "${IMAGE_WITH_REGISTRY}:latest",
     "${IMAGE_WITH_REGISTRY}:3",
-    "${IMAGE_WITH_REGISTRY}:3.5",
+    "${IMAGE_WITH_REGISTRY}:3.6",
   ]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -313,8 +313,9 @@ target "kafka-3_5" {
     SCALA_VERSION = "2.13"
   }
   tags = [
-    "${IMAGE_WITH_REGISTRY}:3.5.1",
-    "${IMAGE_WITH_REGISTRY}:v3.5.1",
+    "${IMAGE_WITH_REGISTRY}:3.5.2",
+    "${IMAGE_WITH_REGISTRY}:v3.5.2",
+    "${IMAGE_WITH_REGISTRY}:3.5",
   ]
 }
 


### PR DESCRIPTION
https://kafka.apache.org/downloads

3.6.1 is the latest release. The current stable version is 3.6.1